### PR TITLE
Initial Touch Events

### DIFF
--- a/sandbox/App.vue
+++ b/sandbox/App.vue
@@ -241,7 +241,7 @@
 <style lang="scss" scoped>
   .timeline {
     border: 1px solid color-mix(in srgb, currentcolor 10%, transparent);
-
+    touch-action: none;
     --font-family: system-ui, -apple-system, blinkmacsystemfont, "Segoe UI", roboto, oxygen, ubuntu, cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 
     // --gridline-border-left: 1px dashed rgba(255, 255, 255, 10%);


### PR DESCRIPTION
This PR adds the ability for the timeline to be dragged with one finger left and right for horizontal scroll. It also adds two finger detection for pinch to zoom. Additionally pointer events that would fire alongside are simple exited by detection of the pointerType. This was tested on the sandbox App in Safari, Chrome, and on a physical iPhone. This should address issue #11 for the first two bullets and I would like add options, but am unsure which ones would be best. e.g.