### PR TITLE
Mobile touch events

### DIFF
--- a/sandbox/App.vue
+++ b/sandbox/App.vue
@@ -241,7 +241,7 @@
 <style lang="scss" scoped>
   .timeline {
     border: 1px solid color-mix(in srgb, currentcolor 10%, transparent);
-
+    touch-action: none;
     --font-family: system-ui, -apple-system, blinkmacsystemfont, "Segoe UI", roboto, oxygen, ubuntu, cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 
     // --gridline-border-left: 1px dashed rgba(255, 255, 255, 10%);


### PR DESCRIPTION
Updated PR with constraints for touch events for horizontal drag and pinch/zoom. Added an animation function for a slight effect when dragging beyond bounds. This now respects viewport constraints as well. Let me know if additional edits are needed or if certain use cases haven't been met. The only item that isn't really included is the backgrounds > background marker for placement since that and the horizontal drag won't work in tandem. It will jump to a Touch Event so maybe it's just a documentation item. I've also tested in an external application with heavy overrides on slots etc.